### PR TITLE
Fixed order email URL and ALLOWED_HOSTS too.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ PUBLIC_ROOT=/web/pyment-site
 # mail
 EMAIL_URL='smtps://username@domain.org:password@mailhost:port'
 EMAIL_SUBJECT_PREFIX='[Pyment] '
+
+# hosts
+USE_X_FORWARDED_HOST=True
+ALLOWED_HOSTS=.example.org,
 ```
 
 Modify the file to reflect your site's requirements.  Generate your own secret key for Django and use it in the file.  Sync the database and start the admin site.  Create flatpages for "about" and "contact".  This should be enough for the site itself to look right.

--- a/pyment/settings.py
+++ b/pyment/settings.py
@@ -30,7 +30,7 @@ DATABASES = {
 
 # Hosts/domain names that are valid for this site; required if DEBUG is False
 # See https://docs.djangoproject.com/en/1.5/ref/settings/#allowed-hosts
-ALLOWED_HOSTS = ['localhost', '127.0.0.1']
+ALLOWED_HOSTS = env.list('ALLOWED_HOSTS')
 
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name


### PR DESCRIPTION
The real fix to the order email URL  #49  was to fix the nginx
configuration.  Unfortunately, that fix caused ALLOWED_HOSTS to get
excited.  This exposed a deficiency in settings.py configuration which
has since been addressed.  The documentation for the env file has also
been updated.