### PR TITLE
Products missing thumbnails now blocked from category pages.

### DIFF
--- a/meadery/views.py
+++ b/meadery/views.py
@@ -31,9 +31,9 @@ def show_category(request, category_value, template_name='meadery/category.djhtm
     name = names[0]
     description = Product.MEAD_DESCRIPTIONS[intcv]
     if intcv == Product.ALL:
-        products = Product.instock.all()
+        products = Product.instock.exclude(thumbnail='')
     else:
-        products = Product.instock.filter(category=category_value)
+        products = Product.instock.filter(category=category_value).exclude(thumbnail='')
     page_title = name
     return render(request, template_name, locals())
 


### PR DESCRIPTION
If an active product has no thumbnail, it will now not be displayed on
category pages, including the 'All' category.

closes #55 