### PR TITLE
Bring Docker support up-to-date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - "2.7"
 services:
   - postgresql
-env: 
+env:
   global:
     - DATABASE_URL='postgres://postgres@127.0.0.1/travis_ci_db'
     - SECRET_KEY='*n4-$m9(fkr!ghro4=tz!%=0mkv5=90mi%8d$!p^ir@3mm@=zv'
@@ -23,7 +23,7 @@ before_script:
   - python manage.py collectstatic --noinput
   - python manage.py syncdb --noinput
 script:
-  - flake8 --max-line-length=1200 .
+  - flake8 --ignore=E402 --max-line-length=1200 .
   - coverage run --source=. manage.py test
 after_success:
   - coveralls

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ MAINTAINER Jack Twilley <mathuin@gmail.com>
 ENV PYTHONUNBUFFERED 1
 
 # Environment settings
-ENV DEBUG True
 ENV SECRET_KEY 'qkmm6qcxz9npoCxtt8ofRu5vVFeTEfbDIJdmIKiEBIiVCi2ef9'
 ENV PUBLIC_ROOT /public
 ENV ALLOWED_HOSTS localhost,127.0.0.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,15 @@
-FROM phusion/baseimage:0.9.16
-
+FROM python:2.7
 MAINTAINER Jack Twilley <mathuin@gmail.com>
-
-# Port 8000 may be in use by squid-deb-proxy.
-ENV PORTNUM 8001
-
-# Use squid-deb-proxy if present.
-ENV DIRECT_HOSTS ppa.launchpad.net
-
-RUN route -n | awk '/^0.0.0.0/ {print $2}' > /tmp/host_ip.txt
-RUN echo "HEAD /" | nc `cat /tmp/host_ip.txt` 8000 | grep squid-deb-proxy \
-  && (echo "Acquire::http::Proxy \"http://$(cat /tmp/host_ip.txt):8000\";" > /etc/apt/apt.conf.d/30proxy) \
-  && (for host in ${DIRECT_HOSTS}; do echo "Acquire::http::Proxy::$host DIRECT;" >> /etc/apt/apt.conf.d/30proxy; done) \
-  || echo "No squid-deb-proxy detected on docker host"
-
-# Never ask for confirmations
-ENV DEBIAN_FRONTEND noninteractive
-
-RUN apt-get update && apt-get install -y \
-    libpq-dev \
-    python-dev \
-    python-pip
-
 ENV PYTHONUNBUFFERED 1
 
 # Environment settings
 ENV DEBUG True
 ENV SECRET_KEY 'qkmm6qcxz9npoCxtt8ofRu5vVFeTEfbDIJdmIKiEBIiVCi2ef9'
-ENV PUBLIC_ROOT /opt/public
+ENV PUBLIC_ROOT /public
 ENV ALLOWED_HOSTS localhost,127.0.0.1
 
-RUN mkdir -p /opt/app /opt/public
-COPY requirements.txt /opt/requirements.txt
-RUN pip install -r /opt/requirements.txt
-
-WORKDIR /opt/app
-EXPOSE ${PORTNUM}
-CMD [ "python", "manage.py", "runserver", "--insecure", "0.0.0.0:${PORTNUM}" ]
+RUN mkdir /code
+WORKDIR /code
+COPY requirements.txt /code/
+RUN pip install -r requirements.txt
+COPY . /code/

--- a/README.md
+++ b/README.md
@@ -16,11 +16,7 @@ An inventory management system has been implemented, including support for multi
 
 # Requirements
 
-Pyment now runs on Django 1.5.1.  This required minimal changes to the codebase, which is now PEP8-compliant except for line length.  
-
-Pyment is my first experience with virtualenv.  I have created a requirements.txt file from the output of 'pip freeze' which should be enough to recreate my environment.  Please let me know if anything is missing!
-
-In addition to the packages listed in the requirements file, pyment requires python 2.6 or greater.
+Pyment requires Docker Engine 1.10.0+ and Docker Compose 1.6.0+.
 
 # Standard workflow
 
@@ -34,7 +30,7 @@ The first step is to create or select a recipe.  The recipes all follow the same
 4.  (Optional) Add some flavoring to the bucket.
 5.  Take sample, and record observations.
 6.  Pitch yeast.
-	
+
 The information stored in the app focuses on the ingredients.  For instance, multiple types of honey could be used for a particular recipe, or perhaps apple juice instead of water, or maybe some spices for flavor in the case of a metheglin.
 
 The next step is to create a batch based on that recipe.  The values for the recipe will be copied into the batch where they can be modified when the mead is actually brewed.  If the batch's ingredients change significantly, a new recipe can be created.  The batch includes space for observations such as temperature, specific gravity, and tasting notes.  These observations will be useful for determining the strength of the mead and the flavor text for the labels among other factors.  As the batch progresses, it will be updated with samples from time to time.
@@ -47,11 +43,9 @@ The site works like a standard e-commerce site, where orders can be placed.  Fro
 
 # Initial Configuration
 
-Copy pyment/settings.py to pyment/settings_local.py and modify it to suit your environment.
+Copy `pyment/settings.py` to `pyment/settings_local.py` and modify it to suit your environment.
 
-Use the text editor of your choice to create a new file named
-```pyment/.env```.  The following is an example env file which
-includes all the required variables:
+Use the text editor of your choice to create a new file named `pyment/.env`.  The following is an example env file which includes all the required variables:
 
 ```
 # DEBUG must be false for production
@@ -97,45 +91,6 @@ Once all the mead has been entered into the database, take another tour of the s
 
 Simple labels are created by default.  Custom labels can be produced by creating a file 'meadery\_local.py' in the meadery app which contains a 'generate\_labels(batch)' function, plus any supporting code.  If images are used on labels, they must be copied into the static directory and 'collectstatic' must be run.
 
-# Development
-
-Docker and fig are used to assist with developing this software.  Both of these tools should be installed on the host server.  Some variables have required values for development:
-
-```
-# DEBUG must be True when using fig
-DEBUG=True
-
-# Container uses this value
-PUBLIC_ROOT=/opt/public
-```
-
-If ```squid-deb-proxy``` is running on port 8000, the Dockerfile will access the cache when retrieving packages from the Internet.  This can save considerable time when rebuilding images.
-
-The containers can be built using the following command:
-
-```
-$ ./dev-setup.sh
-```
-
-A database dump and collection of media files are both required to construct the containers.  These are not currently supplied, but fixing that has a high priority!
-
-To run the existing test suite, use the following command:
-
-```
-$ fig run web python manage.py shell
-```
-
-To bring up the web site on port 8001:
-
-```
-$ fig up
-```
-
-Thanks!
-
 # License
 
 This software is released under the [MIT license](http://opensource.org/licenses/mit-license.php).
-
-
-

--- a/cart/cart.py
+++ b/cart/cart.py
@@ -21,7 +21,7 @@ def _generate_cart_id():
     characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890!@#$%^&*()'
     cart_id_length = 50
     for y in range(cart_id_length):
-        cart_id += characters[random.randint(0, len(characters)-1)]
+        cart_id += characters[random.randint(0, len(characters) - 1)]
     return cart_id
 
 

--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -1,41 +1,21 @@
 #!/bin/bash
 
 # clean up current situation
-docker-compose stop
-docker-compose rm --force
+docker-compose down -v
 
 # rebuild containers
 docker-compose build
 
-# start data containers
-docker-compose up -d db public
-
-# jumpstart database configuration
-docker-compose run web true
-
 # collectstatic
-docker-compose run web python manage.py collectstatic --noinput
+docker-compose run --rm web python manage.py collectstatic --noinput
 
 # create database
-# due to race conditions, this may require multiple attempts
-retcode=1
-count=0
-while [ $retcode -ne 0 ]; do
-    count=$((count+1))
-    if [ $count -gt 10 ]; then
-      echo "FAIL: ten failed attempts to run syncdb"
-      echo "one last run with stdout and stderr displayed follows!"
-      docker-compose run web python manage.py syncdb --noinput
-      break
-    fi
-    docker-compose run web python manage.py syncdb --noinput >/dev/null 2>/dev/null
-    retcode=$?
-done
+docker-compose run --rm web ./wait-for-it.sh db:5432 -- python manage.py syncdb --noinput
 
 # load fixtures
 apps="accounts checkout meadery inventory"
 fixtures=`for app in $apps; do echo $app/fixtures/$app.json; done | xargs echo`
-docker-compose run web python manage.py loaddata $fixtures
+docker-compose run --rm web python manage.py loaddata $fixtures
 
 # populate media directory
 # docker-compose run web tar -C /opt/public -xf /opt/app/media.tar

--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -18,4 +18,4 @@ fixtures=`for app in $apps; do echo $app/fixtures/$app.json; done | xargs echo`
 docker-compose run --rm web python manage.py loaddata $fixtures
 
 # populate media directory
-# docker-compose run web tar -C /opt/public -xf /opt/app/media.tar
+# docker-compose run web tar -C /public -xf /code/media.tar

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
             - POSTGRES_DATABASE=pyment
     web:
         build: .
-        command: ./wait-for-it.sh db:5432 -- python manage.py runserver 0.0.0.0:8000
+        command: ./wait-for-it.sh db:5432 -- python manage.py runserver --insecure 0.0.0.0:8000
         volumes:
             - public:/public
             - .:/code
@@ -19,7 +19,7 @@ services:
         depends_on:
             - db
         environment:
-            -  DATABASE_URL=postgres://pyment:pyment_password@db:5432/pyment
+            - DATABASE_URL=postgres://pyment:pyment_password@db:5432/pyment
 volumes:
     dbdata:
         driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,37 +1,27 @@
-dbdata:
-  image: postgres:9.4
-  volumes:
-    - /var/lib/postgresql/data
-  command: true
-
-db:
-  image: postgres:9.4
-  volumes_from:
-    - dbdata
-  ports:
-    - "5432"
-  environment:
-    - POSTGRES_USER=pyment
-    - POSTGRES_PASSWORD=pyment_password
-    - POSTGRES_DATABASE=pyment
-
-public:
-  image: phusion/baseimage:0.9.16
-  volumes:
-    - /opt/public
-  command: true
-
-web:
-  build: .
-  command: python manage.py runserver 0.0.0.0:8001
-  volumes:
-    - .:/opt/app/
-  volumes_from:
-    - public
-  ports:
-    - "8001:8001"
-  links:
-    - db
-  environment:
-    - DJANGO_SETTINGS_MODULE=pyment.settings
-    - DATABASE_URL=postgres://pyment:pyment_password@db:5432/pyment
+version: '2'
+services:
+    db:
+        image: postgres:9.4
+        volumes:
+            - dbdata:/var/lib/postgresql/data
+        environment:
+            - POSTGRES_USER=pyment
+            - POSTGRES_PASSWORD=pyment_password
+            - POSTGRES_DATABASE=pyment
+    web:
+        build: .
+        command: ./wait-for-it.sh db:5432 -- python manage.py runserver 0.0.0.0:8000
+        volumes:
+            - public:/public
+            - .:/code
+        ports:
+            - "8000:8000"
+        depends_on:
+            - db
+        environment:
+            -  DATABASE_URL=postgres://pyment:pyment_password@db:5432/pyment
+volumes:
+    dbdata:
+        driver: local
+    public:
+        driver: local

--- a/docs/source/copyright.rst
+++ b/docs/source/copyright.rst
@@ -1,7 +1,7 @@
 Copyright
 =========
 
-Copyright 2012-2015 Jack Twilley <mathuin@gmail.com>
+Copyright 2012-2016 Jack Twilley <mathuin@gmail.com>
 
 Contributors
 ------------

--- a/docs/source/dev.rst
+++ b/docs/source/dev.rst
@@ -8,7 +8,7 @@ The ``pyment`` source code is hosted on GitHub. ::
 
     $ git clone git://github.com/mathuin/pyment
 
-The `GitHub Flow`_ development model is used for this project.  
+The `GitHub Flow`_ development model is used for this project.
 
 All pull requests should be created from the ``master`` branch, and
 should include relevant updates to the documentation.
@@ -18,42 +18,34 @@ presence of the bug and its eradication.
 
 .. _`GitHub Flow`: https://guides.github.com/introduction/flow/
 
-Using docker and fig
---------------------
+Using docker and docker-compose
+-------------------------------
 
-Docker and fig are used to assist with developing this software.  Both
-of these tools should be installed on the host server.  Some variables
-have required values for development: ::
-
-    # DEBUG must be True when using fig
-    DEBUG=True
-
-    # Container uses this value
-    PUBLIC_ROOT=/opt/public
-
-.. note:: If `squid-deb-proxy`_ is running on port 8000, the Dockerfile
-   will access the cache when retrieving packages from the Internet.
-   This can save considerable time when rebuilding images.
+Docker and docker-compose are used to assist with developing this software.
+Both of these tools should be installed on the host server.
 
 The containers can be built with the following command: ::
 
-    $ fig build
+    $ docker-compose build
 
 To run the existing test suite, use the following command: ::
 
-    $ fig run web python manage.py test
+    $ docker-compose run --rm web python manage.py test
 
 The containers can be rebuilt and populated with test data using the
 following command: ::
 
     $ ./dev-setup.sh
 
-.. todo:: A database dump and collection of media files are both
-   required to run this command.  These are not currently supplied,
-   but fixing that has a high priority!
+To bring up the web site on port 8000: ::
 
-To bring up the web site on port 8001: ::
+    $ docker-compose up
 
-    $ fig up
+Updating documentation
+----------------------
 
-.. _`squid-deb-proxy`: https://launchpad.net/squid-deb-proxy
+This documentation is generated using Sphinx.
+
+To rebuild the documentation after changes: ::
+
+    $ docker-compose run --rm web make -C docs html

--- a/inventory/management/commands/add_new_jars.py
+++ b/inventory/management/commands/add_new_jars.py
@@ -47,7 +47,7 @@ class Command(BaseCommand):
         except ValueError:
             raise CommandError('End jar value is not an int: %s' % options['end_jar'])
         try:
-            jar_list = [x for x in xrange(start_jar, end_jar+1)]
+            jar_list = [x for x in xrange(start_jar, end_jar + 1)]
         except NameError:
             raise CommandError('Start jar and end jar required!')
         except TypeError:

--- a/inventory/management/commands/crate_utilization.py
+++ b/inventory/management/commands/crate_utilization.py
@@ -38,9 +38,9 @@ class Command(BaseCommand):
         dataformat = '{0:^%dd}|{1:^%ds}|{2:^%dd}|{3:^%dd}\n' % fieldwidths
         headerline = headerformat.format('Crate ID', 'Bin', 'Capacity', 'Jars')
         self.stdout.write(headerline)
-        self.stdout.write('='*len(headerline))
-        for crate in sorted(Crate.objects.filter(bin__in=Bin.objects.filter(shelf__in=Shelf.objects.filter(row__in=Row.objects.filter(warehouse=warehouse)))), key=lambda c: c.jars*1.0/c.capacity):
+        self.stdout.write('=' * len(headerline))
+        for crate in sorted(Crate.objects.filter(bin__in=Bin.objects.filter(shelf__in=Shelf.objects.filter(row__in=Row.objects.filter(warehouse=warehouse)))), key=lambda c: c.jars * 1.0 / c.capacity):
             if (crate.jars != crate.capacity and crate.jars != 0) or (options['full'] and crate.jars == crate.capacity) or (options['empty'] and crate.jars == 0):
                 # The warehouse is superfluous here
-                loc = crate.bin.longname[len(warehouse.longname)+1:]
+                loc = crate.bin.longname[len(warehouse.longname) + 1:]
                 self.stdout.write(dataformat.format(crate.id, loc, crate.capacity, crate.jars))

--- a/meadery/labels.py
+++ b/meadery/labels.py
@@ -30,8 +30,8 @@ class Sheet:
         self.col_gutter = 9
 
         # Calculate label width and height.
-        self.labelw = int((self.width - self.left_margin - self.right_margin - (self.cols - 1)*self.col_gutter) / self.cols)
-        self.labelh = int((self.height - self.top_margin - self.bottom_margin - (self.rows - 1)*self.row_gutter) / self.rows)
+        self.labelw = int((self.width - self.left_margin - self.right_margin - (self.cols - 1) * self.col_gutter) / self.cols)
+        self.labelh = int((self.height - self.top_margin - self.bottom_margin - (self.rows - 1) * self.row_gutter) / self.rows)
 
         # Get sample style sheet from styles.
         self.styles = getSampleStyleSheet()
@@ -41,7 +41,7 @@ class Sheet:
         self.doc = BaseDocTemplate(self.buffer, pagesize=(self.width, self.height))
 
         # Construct page template of "frames".  Each frame contains one label.
-        self.framelist = [(self.left_margin+y*(self.col_gutter+self.labelw), self.height-self.bottom_margin-self.labelh-x*(self.row_gutter+self.labelh), self.labelw, self.labelh) for x in xrange(self.rows) for y in xrange(self.cols)]
+        self.framelist = [(self.left_margin + y * (self.col_gutter + self.labelw), self.height - self.bottom_margin - self.labelh - x * (self.row_gutter + self.labelh), self.labelw, self.labelh) for x in xrange(self.rows) for y in xrange(self.cols)]
         self.doc.addPageTemplates([PageTemplate(frames=[Frame(a, b, c, d, leftPadding=0, bottomPadding=0, rightPadding=0, topPadding=0, showBoundary=(1 if self.debug else 0)) for (a, b, c, d) in self.framelist])])
 
     def __call__(self, data):
@@ -71,7 +71,7 @@ class Label:
 
     # init
     def __init__(self, seq, batch, debug=False):
-        self.seq = '{0}{1}'.format(batch.batchletter, seq+1)
+        self.seq = '{0}{1}'.format(batch.batchletter, seq + 1)
         self.batch = batch
         self.debug = debug
 

--- a/meadery/models.py
+++ b/meadery/models.py
@@ -110,7 +110,7 @@ class IngredientItem(models.Model):
 
     @property
     def to_c(self):
-        return Decimal((self.temp-32)/1.8).quantize(Decimal('0.1'))
+        return Decimal((self.temp - 32) / 1.8).quantize(Decimal('0.1'))
 
 
 class ParentManager(models.Manager):
@@ -165,7 +165,7 @@ class Parent(models.Model):
                           (CATEGORY_ALL, ALL_CATEGORIES))
     MEAD_CHOICES = tuple((b, d) for ((a, b), (c, d)) in zip(MEAD_CATEGORIES, MEAD_SUBCATEGORIES))
     # JMT: it would be awesome to redo categories to support two levels!
-    MEAD_VIEWS = reduce(lambda t1, t2: t1+t2, [categories for (topvalue, categories) in MEAD_CHOICES])
+    MEAD_VIEWS = reduce(lambda t1, t2: t1 + t2, [categories for (topvalue, categories) in MEAD_CHOICES])
     MEAD_DESCRIPTIONS = {TRADITIONAL_DRY: 'A traditional mead with subtle honey aroma but no significant aromatics. Minimal residual sweetness with a dry finish, and a light to medium body. Similar to a dry white wine. (Based on BJCP Style Guidelines 2008)',
                          TRADITIONAL_SEMI_SWEET: 'A traditional mead with noticeable honey aroma and subtle to moderate residual sweetness with a medium-dry finish.  Body is medium-light to medium-full.  Similar to a semi-sweet (or medium-dry) white wine.  (thanks to BJCP Style Guidelines 2008)',
                          TRADITIONAL_SWEET: 'A traditional mead with dominating honey aroma, often moderately to strongly sweet.  The body is generally medium-full to full, and may seem like a dessert wine.  (thanks to BJCP Style Guidelines 2008)',
@@ -319,7 +319,7 @@ class Batch(SIPParent):
             firstsg = self.sample_set.order_by('date')[0].corrsg
             lastsg = self.sample_set.order_by('-date')[0].corrsg
             if firstsg != zero and lastsg != zero and firstsg > lastsg:
-                return Decimal(Decimal('100')*(firstsg - lastsg)/Decimal('0.75')).quantize(Decimal('0.01'))
+                return Decimal(Decimal('100') * (firstsg - lastsg) / Decimal('0.75')).quantize(Decimal('0.01'))
             else:
                 return None
         else:
@@ -337,13 +337,13 @@ class Sample(models.Model):
     deltasg = [-0.0007, -0.0008, -0.0008, -0.0009, -0.0009,
                -0.0009, -0.0008, -0.0008, -0.0007, -0.0007,
                -0.0006, -0.0005, -0.0004, -0.0003, -0.0001,
-               0.0000,  0.0002,  0.0003,  0.0005,  0.0007,
-               0.0009,  0.0011,  0.0013,  0.0016,  0.0018,
-               0.0021,  0.0023,  0.0026,  0.0029,  0.0032,
-               0.0035,  0.0038,  0.0041,  0.0044,  0.0047,
-               0.0051,  0.0054,  0.0058,  0.0061,  0.0065,
-               0.0069,  0.0073,  0.0077,  0.0081,  0.0085,
-               0.0089,  0.0093,  0.0097,  0.0102,  0.0106]
+               0.0000, 0.0002, 0.0003, 0.0005, 0.0007,
+               0.0009, 0.0011, 0.0013, 0.0016, 0.0018,
+               0.0021, 0.0023, 0.0026, 0.0029, 0.0032,
+               0.0035, 0.0038, 0.0041, 0.0044, 0.0047,
+               0.0051, 0.0054, 0.0058, 0.0061, 0.0065,
+               0.0069, 0.0073, 0.0077, 0.0081, 0.0085,
+               0.0089, 0.0093, 0.0097, 0.0102, 0.0106]
 
     class Meta:
         ordering = ('date', )
@@ -354,7 +354,7 @@ class Sample(models.Model):
     @property
     def corrsg(self):
         # Convert temperature from Fahrenheit to Celsius first.
-        tempC = int((self.temp-32)/1.8)
+        tempC = int((self.temp - 32) / 1.8)
         return Decimal(self.sg + Decimal(str(Sample.deltasg[tempC]))).quantize(Decimal('0.001'))
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,11 +3,8 @@ python-decouple==2.3
 unipath
 dj-database-url
 dj-email-url
-docker-compose==1.2.0
-gunicorn==19.2.1
 Pillow
 psycopg2==2.6
 reportlab==3.1.44
 Sphinx
 hieroglyph
-coverage

--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+#   Use this script to test if a given TCP host/port are available
+
+cmdname=$(basename $0)
+
+echoerr() { if [[ $QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $TIMEOUT -gt 0 ]]; then
+        echoerr "$cmdname: waiting $TIMEOUT seconds for $HOST:$PORT"
+    else
+        echoerr "$cmdname: waiting for $HOST:$PORT without a timeout"
+    fi
+    start_ts=$(date +%s)
+    while :
+    do
+        (echo > /dev/tcp/$HOST/$PORT) >/dev/null 2>&1
+        result=$?
+        if [[ $result -eq 0 ]]; then
+            end_ts=$(date +%s)
+            echoerr "$cmdname: $HOST:$PORT is available after $((end_ts - start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $QUIET -eq 1 ]]; then
+        timeout $TIMEOUT $0 --quiet --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    else
+        timeout $TIMEOUT $0 --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    fi
+    PID=$!
+    trap "kill -INT -$PID" INT
+    wait $PID
+    RESULT=$?
+    if [[ $RESULT -ne 0 ]]; then
+        echoerr "$cmdname: timeout occurred after waiting $TIMEOUT seconds for $HOST:$PORT"
+    fi
+    return $RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* ) 
+        hostport=(${1//:/ })
+        HOST=${hostport[0]}
+        PORT=${hostport[1]}
+        shift 1
+        ;;
+        --child)
+        CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        STRICT=1
+        shift 1
+        ;;
+        -h) 
+        HOST="$2"
+        if [[ $HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*) 
+        HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        PORT="$2"
+        if [[ $PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        TIMEOUT="$2"
+        if [[ $TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        CLI="$@"
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$HOST" == "" || "$PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+TIMEOUT=${TIMEOUT:-15}
+STRICT=${STRICT:-0}
+CHILD=${CHILD:-0}
+QUIET=${QUIET:-0}
+
+if [[ $CHILD -gt 0 ]]; then
+    RESULT=$(wait_for)
+    exit $RESULT
+else
+    if [[ $TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        RESULT=$?
+    else
+        RESULT=$(wait_for)
+    fi
+fi
+
+if [[ $CLI != "" ]]; then
+    if [[ $RESULT -ne 0 && $STRICT -eq 1 ]]; then
+        echoerr "$cmdname: strict mode, refusing to execute subprocess"
+        exit $RESULT
+    fi
+    exec $CLI
+else
+    exit $RESULT
+fi


### PR DESCRIPTION
The state of the art in Docker containers has advanced quite a bit since
support was originally added.

The container image has reverted to Python 2.7, and the squid-deb-proxy support
has been removed.  The data-only containers have been replaced with named
volumes and moved to the root directory.  The app itself now resides in /code.

The dev setup script has also been cleaned up quite a bit.  A number of ugly
workarounds are no longer necessary and were removed.

The Dockerfile has been updated to version 2 and cleaned up in general.

The worst kludge of them all was replaced with a best-practices script which
waits for the database to start before performing db-related app tasks.  Many
thanks to https://github.com/vishnubob/wait-for-it for solving that problem!