### PR TITLE
Updated checkout reverse URLs

### DIFF
--- a/django/checkout/checkout.py
+++ b/django/checkout/checkout.py
@@ -9,7 +9,7 @@ from pyment import settings
 
 
 def get_checkout_url(request):
-    return reverse('checkout')
+    return reverse('checkout:checkout')
 
 
 def process(request):

--- a/django/checkout/views.py
+++ b/django/checkout/views.py
@@ -22,7 +22,7 @@ def show_checkout(request, template_name='checkout/checkout.html'):
             error_message = response.get('message', '')
             if order_number:
                 request.session['order_number'] = order_number
-                receipt_url = reverse('checkout_receipt')
+                receipt_url = reverse('checkout:checkout_receipt')
                 return HttpResponseRedirect(receipt_url)
         else:
             error_message = 'Correct the errors below'


### PR DESCRIPTION
These calls to reverse() were missed on the previous run.

There are no tests for this functionality in checkout.  That should probably change someday.